### PR TITLE
Add to readme instruction for quick configuration of release bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ This repository contains bundles which the Helm Broker uses. It allows you to ch
 
 The `bundles` folder contains sources of bundles and index files. These files are available in [releases](https://github.com/kyma-project/bundles/releases). To learn more about the release process, read [this](docs/releasing.md) document.
 
+To quickly configure one of the released bundles follow below steps:
+```
+URLS=$(kubectl get -n kyma-system deployment/core-helm-broker --output=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="APP_REPOSITORY_URLS")].value}')
+#This step registers testing bundle
+kubectl set env -n kyma-system deployment/core-helm-broker -e APP_REPOSITORY_URLS="$URLS;https://github.com/kyma-project/bundles/releases/download/0.2.0/index-testing.yaml"
+```
+
 If you want to configure the Helm Broker to use different set of bundles, read the [Helm Broker configuration](https://github.com/kyma-project/kyma/blob/master/docs/service-brokers/docs/011-configuration-helm-broker.md) and configure the proper URL.
  
 ## Development 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ URLS=$(kubectl get -n kyma-system deployment/core-helm-broker --output=jsonpath=
 kubectl set env -n kyma-system deployment/core-helm-broker -e APP_REPOSITORY_URLS="$URLS;https://github.com/kyma-project/bundles/releases/download/0.2.0/index-testing.yaml"
 ```
 
-If you want to configure the Helm Broker to use different set of bundles, read the [Helm Broker configuration](https://github.com/kyma-project/kyma/blob/master/docs/service-brokers/docs/011-configuration-helm-broker.md) and configure the proper URL.
+If you want to configure the Helm Broker to use different set of bundles, read the [Helm Broker configuration](https://kyma-project.io/docs/components/service-brokers#configuration-configure-helm-broker) and configure the proper URL.
  
 ## Development 
  
-Develop your own remote `bundles` repository forked from the original repository. Read [this](docs/getting-started.md) document to learn how. On your fork, you can create your own bundles with a structure described in the [Helm Broker bundles](https://github.com/kyma-project/kyma/blob/master/docs/service-brokers/docs/012-configuration-helm-broker-bundles.md) document. Read also the [`CONTRIBUTING.md`](CONTRIBUTING.md) document that includes the contributing rules specific for this repository.
+Develop your own remote `bundles` repository forked from the original repository. Read [this](docs/getting-started.md) document to learn how. On your fork, you can create your own bundles with a structure described in the [Helm Broker bundles](https://kyma-project.io/docs/components/service-brokers#configuration-how-to-create-a-bundle) document. Read also the [`CONTRIBUTING.md`](CONTRIBUTING.md) document that includes the contributing rules specific for this repository.
 
 ### Project structure
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The `bundles` folder contains sources of bundles and index files. These files ar
 To quickly configure one of the released bundles, follow these steps:
 ```
 URLS=$(kubectl get -n kyma-system deployment/core-helm-broker --output=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="APP_REPOSITORY_URLS")].value}')
-# This step registers the testing bundle
 
+# This step registers the testing bundle in version 0.2.0
 kubectl set env -n kyma-system deployment/core-helm-broker -e APP_REPOSITORY_URLS="$URLS;https://github.com/kyma-project/bundles/releases/download/0.2.0/index-testing.yaml"
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains bundles which the Helm Broker uses. It allows you to ch
 
 The `bundles` folder contains sources of bundles and index files. These files are available in [releases](https://github.com/kyma-project/bundles/releases). To learn more about the release process, read [this](docs/releasing.md) document.
 
-To quickly configure one of the released bundles follow below steps:
+To quickly configure one of the released bundles, follow these steps:
 ```
 URLS=$(kubectl get -n kyma-system deployment/core-helm-broker --output=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="APP_REPOSITORY_URLS")].value}')
 #This step registers testing bundle

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains bundles which the Helm Broker uses. It allows you to ch
 
 The `bundles` folder contains sources of bundles and index files. These files are available in [releases](https://github.com/kyma-project/bundles/releases). To learn more about the release process, read [this](docs/releasing.md) document.
 
-To quickly extend Helm Broker in Kyma with optional testing bundles, follow these steps:
+To quickly extend the Helm Broker in Kyma with optional testing bundles, follow these steps:
 ```
 URLS=$(kubectl get -n kyma-system deployment/core-helm-broker --output=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="APP_REPOSITORY_URLS")].value}')
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ This repository contains bundles which the Helm Broker uses. It allows you to ch
 
 The `bundles` folder contains sources of bundles and index files. These files are available in [releases](https://github.com/kyma-project/bundles/releases). To learn more about the release process, read [this](docs/releasing.md) document.
 
-To quickly configure one of the released bundles, follow these steps:
+To quickly extend Helm Broker in Kyma with optional testing bundles, follow these steps:
 ```
 URLS=$(kubectl get -n kyma-system deployment/core-helm-broker --output=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="APP_REPOSITORY_URLS")].value}')
 
-# This step registers the testing bundle in version 0.2.0
 kubectl set env -n kyma-system deployment/core-helm-broker -e APP_REPOSITORY_URLS="$URLS;https://github.com/kyma-project/bundles/releases/download/0.2.0/index-testing.yaml"
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The `bundles` folder contains sources of bundles and index files. These files ar
 To quickly configure one of the released bundles, follow these steps:
 ```
 URLS=$(kubectl get -n kyma-system deployment/core-helm-broker --output=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="APP_REPOSITORY_URLS")].value}')
-#This step registers testing bundle
+# This step registers the testing bundle
+
 kubectl set env -n kyma-system deployment/core-helm-broker -e APP_REPOSITORY_URLS="$URLS;https://github.com/kyma-project/bundles/releases/download/0.2.0/index-testing.yaml"
 ```
 


### PR DESCRIPTION
**Description**

Long term please consider adding release specific quick config instruction on a release level here https://github.com/kyma-project/bundles/releases/tag/0.2.0 like it is done with Kyma. For pro users that just need to do copy/paste it is much nicer experience.

Changes proposed in this pull request:

- Add to readme instruction for quick configuration of release bundle