### PR TITLE
Add provisionOnlyOnce flag for broker bundles, remove quickly extend section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,6 @@ This repository contains bundles which the Helm Broker uses. It allows you to ch
 
 The `bundles` folder contains sources of bundles and index files. These files are available in [releases](https://github.com/kyma-project/bundles/releases). To learn more about the release process, read [this](docs/releasing.md) document.
 
-To quickly extend the Helm Broker in Kyma with optional testing bundles, follow these steps:
-```
-URLS=$(kubectl get -n kyma-system deployment/core-helm-broker --output=jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="APP_REPOSITORY_URLS")].value}')
-
-kubectl set env -n kyma-system deployment/core-helm-broker -e APP_REPOSITORY_URLS="$URLS;https://github.com/kyma-project/bundles/releases/download/0.2.0/index-testing.yaml"
-```
-
 If you want to configure the Helm Broker to use different set of bundles, read the [Helm Broker configuration](https://kyma-project.io/docs/components/service-brokers#configuration-configure-helm-broker) and configure the proper URL.
  
 ## Development 

--- a/bundles/azure-service-broker-0.0.1/meta.yaml
+++ b/bundles/azure-service-broker-0.0.1/meta.yaml
@@ -10,3 +10,4 @@ longDescription: Azure Broker is an implementation of the open-source Open Servi
 documentationURL: https://github.com/Azure/open-service-broker-azure/blob/master/README.md
 imageURL: https://www.cloudfoundry.org/wp-content/uploads/2017/10/icon_azure@2x.png
 bindable: false
+provisionOnlyOnce: true

--- a/bundles/gcp-service-broker-0.0.2/meta.yaml
+++ b/bundles/gcp-service-broker-0.0.2/meta.yaml
@@ -10,3 +10,4 @@ longDescription: Google Cloud Platform (GCP) Service Broker is an implementation
 documentationURL: https://cloud.google.com/kubernetes-engine/docs/concepts/google-cloud-platform-service-broker
 imageURL: https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/apple-icon.png
 bindable: false
+provisionOnlyOnce: true


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove the quickly extend section from the main README.md. Will be moved to the release notes. 
- Add **provisionOnlyOnce** flag for each broker bundle 

**Related issue(s)**

- https://github.com/kyma-project/kyma/issues/1716