### PR TITLE
Azure Service Broker bundles updated to app tag: v1.5.0

### DIFF
--- a/bundles/azure-service-broker-0.0.1/chart/azure-service-broker/values.yaml
+++ b/bundles/azure-service-broker-0.0.1/chart/azure-service-broker/values.yaml
@@ -5,7 +5,7 @@ image:
   ## Image location, NOT including the tag
   repository: microsoft/azure-service-broker
   ## Image tag
-  tag: v1.4.0
+  tag: v1.5.0
   ## "IfNotPresent", "Always", or "Never"
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
https://github.com/Azure/open-service-broker-azure/issues/666 has beed solved and released. We need to update existing bundle repo release 0.3.0 with that change. That will automagically appear in a customer clusters.

Chart between v1.4.0 and v1.5.0 has beed checked. No diff besides image version.


**Description**

Changes proposed in this pull request:

- Azure Service Broker service classes Icons are back!

