### PR TITLE
Remove HTML tags from markdown in testing bundle docs

### DIFF
--- a/bundles/testing-0.0.1/docs/plans-details.md
+++ b/bundles/testing-0.0.1/docs/plans-details.md
@@ -5,7 +5,7 @@ type: Details
 
 ## Hodor! Hodor hodor.
 
-Hodor... Hodor hodor. Hodor, hodor <a href="https://gameofthrones.fandom.com/wiki/Hodor" alt="Hodor" id="hodorlink">Hodor</a> Hodor, hodor. Hodor... Hodor hodor. Hodor, hodor.
+Hodor... Hodor hodor. Hodor, hodor  [Hodor](https://gameofthrones.fandom.com/wiki/Hodor) Hodor, hodor. Hodor... Hodor hodor. Hodor, hodor.
 
 | Hodor! | Hodor hodor. |
 |--------|--------------|
@@ -29,7 +29,7 @@ Hodor. Hodor. Hodor hodor! Hodor hodor! Hodor?
 
 Hodor! Hodor hodor. Hodor hodor! Hodor, hodor, hodor hodor. Hodor hodor. HODOR HODOR! HODOR HODOR! Hodor hodor HODOR!
 
-<img src="assets/hodor.png" alt="Hodor" id="hodorimg" />
+![Hodor](assets/hodor.png "hodorimg")
 
 Hodor. Hodor, hodor. Hodor. Hodor, hodor, hodor hodor. HODOR hodor, hodor. Hodor? Hodor hodor! Hodor, hodor, hodor hodor.
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- as in title: Remove HTML tags from markdown in testing bundle docs, as they do not work in console, I've made issue for that: https://github.com/kyma-project/console/issues/909

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Connected to https://github.com/kyma-project/kyma/issues/3766